### PR TITLE
Make knex version a peer dep

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,10 +1,11 @@
 ## Upgrading to new versions
-___
 
-### Upgrading to 2.0+
+---
 
-* No changes required
+### Upgrading to 2.0.0+
+
+- No changes required
 
 ### Upgrading to 1.0.0+
 
-* __BREAKING CHANGES:__ Imports for `knex` have changed. Please read the information regarding upgrading knex found [here](https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950)
+- **BREAKING CHANGES:** Imports for `knex` have changed. Please read the information regarding upgrading knex found [here](https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+## Upgrading to new versions
+___
+
+### Upgrading to 2.0+
+
+* No changes required
+
+### Upgrading to 1.0.0+
+
+* __BREAKING CHANGES:__ Imports for `knex` have changed. Please read the information regarding upgrading knex found [here](https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/db-kit",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/db-kit",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,6 +15,9 @@
   },
   "author": "Dominic Smith",
   "license": "MIT",
+  "peerDependencies": {
+    "knex": "2.x"
+  },
   "dependencies": {
     "@types/camelcase-keys": "^4.1.0",
     "@types/decamelize": "^1.2.0",


### PR DESCRIPTION
- Added `UPGRADING.md` file to document any breaking changes
- Added knex 2.x as peer dependency for version 2.X.X of this library.

NOTE: This has been updated to a RC release so that the peer dependencies can be tested before pushing to prod.