### PR TITLE
Promote 1.1.0-rc.0 to release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/db-kit",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/db-kit",
-      "version": "1.1.0-rc.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/camelcase-keys": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/db-kit",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Tested the release candidate in ops-manager to verify peer dependencies working as expected

knex is correctly registered as a peer dependency

<img width="908" alt="Screenshot 2022-11-08 at 9 17 19 am" src="https://user-images.githubusercontent.com/7439294/200428390-1a27cb28-087d-4759-8cca-b5200c0630f7.png">

Project still builds/tests/runs as expected even with knex removed form ops-manager dependencies (as you can see above is installed automatically as a peer dependency on node 16)

<img width="1478" alt="Screenshot 2022-11-08 at 9 17 55 am" src="https://user-images.githubusercontent.com/7439294/200428545-15779dd8-6537-4e64-a87e-a53a235d2bdd.png">
