### PR TITLE
Node 18 and move prom-client to dev dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: npm ci
       # - run: npm i -D prom-client@${{matrix.prom-client-version}}
       - run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        prom-client-version: [11]
+    runs-on: ubuntu-latest
+    name: Build with Prom Client ${{matrix.prom-client-version}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - run: npm ci
+      # - run: npm i -D prom-client@${{matrix.prom-client-version}}
+      - run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        prom-client-version: [11]
+        prom-client-version: [11, 12, 13, 14]
     runs-on: ubuntu-latest
     name: Build with Prom Client ${{matrix.prom-client-version}}
     steps:
@@ -16,5 +16,5 @@ jobs:
         with:
           node-version: 18
       - run: npm ci
-      # - run: npm i -D prom-client@${{matrix.prom-client-version}}
+      - run: npm i -D prom-client@${{matrix.prom-client-version}}
       - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18
       - run: npm install
       - uses: JS-DevTools/npm-publish@v1
         with:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,7 +1,9 @@
-## Upgrading to new versions
+# Upgrading to new versions
 
----
+## Upgrading to 2.0.0+
 
-### Upgrading to 1.0.0+
+The `prom-client` library has been moved to a peer depencency and will need to be installed seperately in consuming projects.
+
+## Upgrading to 1.0.0+
 
 - **BREAKING CHANGES:** Imports for `knex` have changed. Please read the information regarding upgrading knex found [here](https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@types/decamelize": "^1.2.0",
         "camelcase-keys": "^7.0.2",
         "decamelize": "^2.0.0",
-        "prom-client": "^11.3.0",
         "url-auth-redactor": "^1.0.2"
       },
       "devDependencies": {
@@ -21,6 +20,7 @@
         "knex": "^2.3.0",
         "pg": "^8.7.3",
         "prettier": "^1.17.1",
+        "prom-client": "^14.2.0",
         "tslint": "^5.16.0",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.6.3"
@@ -93,9 +93,10 @@
       "dev": true
     },
     "node_modules/bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -684,14 +685,15 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
-      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "dev": true,
       "dependencies": {
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=6.1"
+        "node": ">=10"
       }
     },
     "node_modules/quick-lru": {
@@ -816,11 +818,12 @@
       }
     },
     "node_modules/tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dev": true,
       "dependencies": {
-        "bintrees": "1.0.1"
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/tildify": {
@@ -1004,9 +1007,10 @@
       "dev": true
     },
     "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1437,9 +1441,10 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
-      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -1532,11 +1537,12 @@
       "dev": true
     },
     "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dev": true,
       "requires": {
-        "bintrees": "1.0.1"
+        "bintrees": "1.0.2"
       }
     },
     "tildify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "url-auth-redactor": "^1.0.2"
       },
       "devDependencies": {
-        "@types/node": "^11.13.11",
+        "@types/node": "^18.15.11",
         "knex": "^2.3.0",
         "pg": "^8.7.3",
         "prettier": "^1.17.1",
@@ -60,9 +60,9 @@
       "integrity": "sha512-viw/LG++yGW9GP7ggfDpR+qpBz/NHFEbRTWNumTzebeUlURwfX+sjQfdfbiEoxXgJrj+1G8p4VN/bLquur7Hmg=="
     },
     "node_modules/@types/node": {
-      "version": "11.13.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.11.tgz",
-      "integrity": "sha512-blLeR+KIy26km1OU8yTLUlSyVCOvT6+wPq/77tIA+uSHHa4yYQosn+bbaJqPtWId0wjVClUtD7aXzDbZeKWqig==",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "node_modules/ansi-styles": {
@@ -977,9 +977,9 @@
       "integrity": "sha512-viw/LG++yGW9GP7ggfDpR+qpBz/NHFEbRTWNumTzebeUlURwfX+sjQfdfbiEoxXgJrj+1G8p4VN/bLquur7Hmg=="
     },
     "@types/node": {
-      "version": "11.13.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.11.tgz",
-      "integrity": "sha512-blLeR+KIy26km1OU8yTLUlSyVCOvT6+wPq/77tIA+uSHHa4yYQosn+bbaJqPtWId0wjVClUtD7aXzDbZeKWqig==",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/db-kit",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/db-kit",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/camelcase-keys": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@types/decamelize": "^1.2.0",
     "camelcase-keys": "^7.0.2",
     "decamelize": "^2.0.0",
-    "prom-client": "^11.3.0",
     "url-auth-redactor": "^1.0.2"
   },
   "devDependencies": {
@@ -31,6 +30,7 @@
     "knex": "^2.3.0",
     "pg": "^8.7.3",
     "prettier": "^1.17.1",
+    "prom-client": "^14.2.0",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/db-kit",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url-auth-redactor": "^1.0.2"
   },
   "devDependencies": {
-    "@types/node": "^11.13.11",
+    "@types/node": "^18.15.11",
     "knex": "^2.3.0",
     "pg": "^8.7.3",
     "prettier": "^1.17.1",


### PR DESCRIPTION
This needed the same treatment for prom-client as `@loke/http-kit`.

__Change Summary__

- Move prom-client to "dev dependencies"
- Updated local prom-client to 14 to ensure builds
- Create new CI workflow to build with `prom-client` versions 11, 12, 13 & 14
- Upgrade release CI to use node 18 instead of 14
- Update upgrading documentation to include notes that you have to install prom-client yourself
- Set to version 2.0.0